### PR TITLE
Fix: Update font paths in KV files

### DIFF
--- a/galaxy_runner/galaxy.kv
+++ b/galaxy_runner/galaxy.kv
@@ -16,6 +16,6 @@ MainWidget:
     Label:
         text: root.score_txt
         font_size: dp(20)
-        font_name: 'fonts/Eurostile.ttf'
+        font_name: 'venv/fonts/Eurostile.ttf'
         size_hint: .18, .2
         pos_hint: {"x": 0, "top": 1}

--- a/galaxy_runner/menu.kv
+++ b/galaxy_runner/menu.kv
@@ -8,12 +8,12 @@
             size: self.size
     Label:
         font_size: dp(40)
-        font_name: 'fonts/Sackers-Gothic-Std-Light.ttf'
+        font_name: 'venv/fonts/Sackers-Gothic-Std-Light.ttf'
         text: root.parent.menu_title
         pos_hint: { "center_x": .5, "center_y": .6}
     Button:
         font_size: dp(30)
-        font_name: 'fonts/Eurostile.ttf'
+        font_name: 'venv/fonts/Eurostile.ttf'
         text: root.parent.menu_button_title
         pos_hint: { "center_x": .5, "center_y": .4}
         size_hint: .2, .15


### PR DESCRIPTION
Corrected the `font_name` properties in `galaxy_runner/galaxy.kv` and `galaxy_runner/menu.kv` to point to the font files within the `venv/fonts/` directory.

This resolves an OSError caused by the application not finding the font files after the project structure refactoring.