### PR TITLE
Fix: Resolve game stuck on game over and keyboard input issues

### DIFF
--- a/galaxy_runner/galaxy.py
+++ b/galaxy_runner/galaxy.py
@@ -106,6 +106,8 @@ class MainWidget(RelativeLayout):
         self.current_offset_x = 0
         self.tiles_coordinates = []
         self.score_txt = "SCORE: " + str(self.current_y_loop)
+        self.menu_title = "G A L A X Y   R U N N E R "
+        self.menu_button_title = "START"
         self.pre_fill_tiles_coordinates()
         self.generate_tiles_coordinates()
         self.state_game_over = False
@@ -162,7 +164,7 @@ class MainWidget(RelativeLayout):
 
     def pre_fill_tiles_coordinates(self):
         for i in range(0, 15):
-            self.tiles_coordinates.append((0, i))
+            self.tiles_coordinates.append((0, i + 2)) # Start tiles at y=2 instead of y=0
 
     def generate_tiles_coordinates(self):
         last_x = 0


### PR DESCRIPTION
- I modified `pre_fill_tiles_coordinates` in `galaxy.py` to start initial tiles at a y-coordinate of `i+2` instead of `i`. This prevents an immediate collision when the game starts, which was causing it to get stuck in the "Game Over" state.
- I added a reset for `menu_title` and `menu_button_title` in the `reset_game` method in `galaxy.py` to their default startup values.
- The keyboard input issue, where arrow keys appeared unresponsive, was a symptom of the game being stuck in "Game Over". By resolving the immediate collision, keyboard input should now function as intended during active gameplay.